### PR TITLE
Feature/fix startup time

### DIFF
--- a/lib/Validator/LIVR.pm
+++ b/lib/Validator/LIVR.pm
@@ -4,7 +4,7 @@ use v5.10;
 use strict;
 use warnings FATAL => 'all';
 
-use Carp qw/croak/;
+my $croak = sub {require Carp; goto &Carp::croak};
 
 use Validator::LIVR::Rules::Common;
 use Validator::LIVR::Rules::String;
@@ -77,7 +77,7 @@ sub register_default_rules {
 
     foreach my $rule_name ( keys %rules ) {
         my $rule_builder = $rules{$rule_name};
-        croak "RULE_BUILDER [$rule_name] SHOULD BE A CODEREF" unless ref($rule_builder) eq 'CODE';
+        $croak->("RULE_BUILDER [$rule_name] SHOULD BE A CODEREF") unless ref($rule_builder) eq 'CODE';
 
         $DEFAULT_RULES{$rule_name} = $rule_builder;
     }
@@ -182,7 +182,7 @@ sub register_rules {
 
     foreach my $rule_name ( keys %rules ) {
         my $rule_builder = $rules{$rule_name};
-        croak "RULE_BUILDER [$rule_name] SHOULD BE A CODEREF" unless ref($rule_builder) eq 'CODE';
+        $croak->("RULE_BUILDER [$rule_name] SHOULD BE A CODEREF") unless ref($rule_builder) eq 'CODE';
 
         $self->{validator_builders}{$rule_name} = $rule_builder;
     }

--- a/lib/Validator/LIVR.pm
+++ b/lib/Validator/LIVR.pm
@@ -2,7 +2,7 @@ package Validator::LIVR;
 
 use v5.10;
 use strict;
-use warnings FATAL => 'all';
+use warnings;
 
 my $croak = sub {require Carp; goto &Carp::croak};
 

--- a/lib/Validator/LIVR/Rules/Special.pm
+++ b/lib/Validator/LIVR/Rules/Special.pm
@@ -3,14 +3,12 @@ package Validator::LIVR::Rules::Special;
 use strict;
 use warnings;
 
-use Email::Valid;
-use Regexp::Common qw/URI/;
-use Time::Piece;
-
 our $VERSION = '0.10';
 
 sub email {
-    return sub {
+    require Email::Valid;
+    no warnings 'redefine';
+    *__PACKAGE__::email = sub {
         my $value = shift;
         return if !defined($value) || $value eq '';
         return 'FORMAT_ERROR' if ref($value);
@@ -36,21 +34,25 @@ sub equal_to_field {
 
 
 sub url {
-    return sub {
+    require Regexp::Common::URI;
+    no warnings qw'redefine once';
+    *__PACKAGE__::url = sub {
         my $value = shift;
         return if !defined($value) || $value eq '';
         return 'FORMAT_ERROR' if ref($value);
 
         $value =~ s/#[^#]*$//;
 
-        return 'WRONG_URL' unless lc($value) =~ /^$RE{URI}{HTTP}{-scheme => 'https?'}$/;
+        return 'WRONG_URL' unless lc($value) =~ /^$Regexp::Common::RE{URI}{HTTP}{-scheme => 'https?'}$/;
         return;
     };
 }
 
 
 sub iso_date {
-    return sub {
+    require Time::Piece;
+    no warnings 'redefine';
+    *__PACKAGE__::iso_date = sub {
         my $value = shift;
         return if !defined($value) || $value eq '';
         return 'FORMAT_ERROR' if ref($value);


### PR DESCRIPTION
All test passed normally.

Now start-up time and memory usage is comparable with [Validate::Tiny](https://metacpan.org/pod/Validate::Tiny) if functions Validator::LIVR::Rules::Special::[email, iso_date] is not used.

Disable warnings FATAL => 'all'.
If you really need it, may be do something like this:
`use warnings;`
`if ( exists $ENV{LIVR_FATAL_WARNINGS} ) { warnings->import(FATAL => 'all') }`
