### PR TITLE
'Strict' mode

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,6 +23,7 @@ WriteMakefile(
     },
     PREREQ_PM => {
         'Email::Valid'   => '0',
+        'List::Util'     => '0',
         'Regexp::Common' => '0'
     },
     ( $mm < 6.46

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,7 @@ WriteMakefile(
     },
     PREREQ_PM => {
         'Email::Valid'   => '0',
-        'List::Util'     => '0',
+        'List::Util'     => '1.45',
         'Regexp::Common' => '0'
     },
     ( $mm < 6.46

--- a/lib/Validator/LIVR/Rules/String.pm
+++ b/lib/Validator/LIVR/Rules/String.pm
@@ -82,7 +82,6 @@ sub length_between {
         my $value = shift;
         return if !defined($value) || $value eq '';
         return 'FORMAT_ERROR' if ref($value);
-        print "AAAAA=" . length($value);
         return 'TOO_SHORT' if length($value) < $min_length;
         return 'TOO_LONG' if length($value) > $max_length;
         return;

--- a/t/05-strict.t
+++ b/t/05-strict.t
@@ -1,0 +1,58 @@
+use strict;
+use warnings;
+use v5.10;
+use lib '../lib';
+
+use Test::More;
+use Test::Exception;
+
+use Validator::LIVR;
+
+my $data = {
+    valid => 1,
+    extra => 1
+};
+
+my $rules = {
+    valid => 'required'
+};
+
+
+subtest 'Validate data with DEFAULT_STRICT' => sub {
+    Validator::LIVR->default_strict(1);
+    my $validator = Validator::LIVR->new($rules);
+    my $output = $validator->validate($data);
+
+    ok( !$output, 'Validation fails' );
+
+    is_deeply($validator->get_errors(), {
+        extra     =>'EXTRA_FIELD'
+    }, 'Should contain error codes' );
+};
+
+subtest 'Validate data with DEFAULT_STRICT set back to 0' => sub {
+    Validator::LIVR->default_strict(0);
+
+    my $validator = Validator::LIVR->new($rules);
+    my $output = $validator->validate($data);
+
+    is_deeply( $output, {
+            valid => 1
+        }, 'Validation succeeds' );
+
+    ok( !$validator->get_errors(), 'Should NOT contain error codes' );
+};
+
+subtest 'Validate data with IS_STRICT set by the constructor' => sub {
+
+    my $validator = Validator::LIVR->new($rules, undef, 1);
+    my $output = $validator->validate($data);
+
+    ok( !$output, 'Validation fails' );
+
+    is_deeply($validator->get_errors(), {
+        extra     =>'EXTRA_FIELD'
+    }, 'Should contain error codes' );
+};
+
+done_testing();


### PR DESCRIPTION
It is desirable (at least for me and colleagues) to be able to have some control over whether extra fields (i.e. those not present explicitly in the ruleset) should be allowed and considered valid (as it is now) or not (that's what lacks in the module). This change implements this functionality by introducing the package variable IS_DEFAULT_STRICT and a corresponding argument to the constructor (similarly to $IS_DEFAULT_AUTO_TRIM). No changes are introduced to the schema specification.
Adds a dependency on List::Util (can be easily removed though).